### PR TITLE
clean up annoy warning in predict.py

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -111,7 +111,7 @@ if __name__ == '__main__':
         indexes = [{'code_tokens': d['function_tokens'], 'language': d['language']} for d in tqdm(definitions)]
         code_representations = model.get_code_representations(indexes)
 
-        indices = AnnoyIndex(code_representations[0].shape[0])
+        indices = AnnoyIndex(code_representations[0].shape[0], 'angular')
         for index, vector in tqdm(enumerate(code_representations)):
             if vector is not None:
                 indices.add_item(index, vector)


### PR DESCRIPTION
Old output from predict:
```
Evaluating language: python
100%|█████████████████████████████████████████████████████████| 1156085/1156085 [00:07<00:00, 147401.78it/s]
./predict.py:114: FutureWarning: The default argument for metric will be removed in future version of Annoy. Please pass metric='angular' explicitly.
  indices = AnnoyIndex(code_representations[0].shape[0])
1156085it [00:36, 32109.11it/s]
Evaluating language: go
```