### PR TITLE
doc: fix fragment link in ToC of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 	- [Setup](#setup)
 - [Data Details](#data-details)
 	- [Data Acquisition](#data-acquisition)
-	- [Schema & Format](#schema-format)
+	- [Schema & Format](#schema--format)
 	- [Downloading Data from S3](#downloading-data-from-s3)
 - [Running our Baseline Model](#running-our-baseline-model)
 	- [Model Architecture](#model-architecture)


### PR DESCRIPTION
A typo in named anchor prevented one link in ToC from working properly