### PR TITLE
Refactor of the Model superclass

### DIFF
--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -1,0 +1,119 @@
+import multiprocessing
+from collections import defaultdict
+from typing import *
+
+from dpu_utils.utils import RichPath
+
+from encoders import Encoder
+from utils.general_utils import get_data_files_from_directory
+
+LoadedSamples = Dict[str, List[Dict[str, Any]]]
+
+
+def parse_data_file(
+        hyperparameters: Dict[str, Any],
+        code_encoder_types: Callable[[str], Type[Encoder]],
+        per_code_language_metadata: Dict[str, Dict[str, Any]],
+        query_encoder_type: Type[Encoder],
+        query_metadata: Dict[str, Any],
+        is_test: bool,
+        data_file: RichPath,
+) -> Dict[str, List[Tuple[bool, Dict[str, Any]]]]:
+    results: DefaultDict[str, List] = defaultdict(list)
+    for raw_sample in data_file.read_by_file_suffix():
+        sample: Dict = {}
+        language = raw_sample['language']
+        if language.startswith('python'):  # In some datasets, we use 'python-2.7' and 'python-3'
+            language = 'python'
+
+        # the load_data_from_sample method call places processed data into sample, and
+        # returns a boolean flag indicating if sample should be used
+        function_name = raw_sample.get('func_name')
+        use_code_flag = code_encoder_types(language).load_data_from_sample(
+            "code",
+            hyperparameters,
+            per_code_language_metadata[language],
+            raw_sample['code_tokens'],
+            function_name,
+            sample,
+            is_test,
+        )
+        use_query_flag = query_encoder_type.load_data_from_sample(
+            "query",
+            hyperparameters,
+            query_metadata,
+            [d.lower() for d in raw_sample['docstring_tokens']],
+            function_name,
+            sample,
+            is_test,
+        )
+        use_example = use_code_flag and use_query_flag
+        results[language].append((use_example, sample))
+    return results
+
+
+class DataLoader:
+    def __init__(
+            self,
+            query_encoder_type: Type[Encoder],
+            code_encoder_types: Callable[[str], Type[Encoder]],
+            hyperparameters: Dict[str, Any],
+            query_metadata: Dict[str, Any],
+            code_metadata: Dict[str, Dict[str, Any]],
+    ):
+        self.query_encoder_type = query_encoder_type
+        self.code_encoder_types = code_encoder_types
+        self.hyperparameters = hyperparameters
+        self.query_metadata = query_metadata
+        self.code_metadata = code_metadata
+
+    def parse_data_file(self, code_metadata, query_metadata, is_test, data_file):
+        return parse_data_file(
+            self.hyperparameters,
+            self.code_encoder_types,
+            code_metadata,
+            self.query_encoder_type,
+            query_metadata,
+            is_test,
+            data_file,
+        )
+
+    def load_data_from_files(
+            self,
+            data_files: Iterable[RichPath], *,
+            is_test: bool,
+            parallelize: bool = True,
+    ) -> Tuple[LoadedSamples, int]:
+        tasks_as_args = [
+            (self.code_metadata, self.query_metadata, is_test, data_file)
+            for data_file in data_files
+        ]
+
+        if parallelize:
+            with multiprocessing.Pool() as pool:
+                per_file_results = pool.starmap(self.parse_data_file, tasks_as_args)
+        else:
+            per_file_results = [self.parse_data_file(*task_args) for task_args in tasks_as_args]
+
+        samples: DefaultDict[str, List] = defaultdict(list)
+        num_all_samples = 0
+        for per_file_result in per_file_results:
+            for (language, parsed_samples) in per_file_result.items():
+                for (use_example, parsed_sample) in parsed_samples:
+                    num_all_samples += 1
+                    if use_example:
+                        samples[language].append(parsed_sample)
+        return samples, num_all_samples
+
+    def load_data_from_dirs(
+            self,
+            data_dirs: List[RichPath], *,
+            is_test: bool,
+            max_files_per_dir: Optional[int] = None,
+            parallelize: bool = True,
+    ) -> Tuple[LoadedSamples, int]:
+        return self.load_data_from_files(
+            list(get_data_files_from_directory(data_dirs, max_files_per_dir)),
+            is_test=is_test,
+            parallelize=parallelize,
+        )

--- a/src/encoders/seq_encoder.py
+++ b/src/encoders/seq_encoder.py
@@ -1,3 +1,4 @@
+from abc import ABCMeta
 from collections import Counter
 import numpy as np
 from typing import Dict, Any, List, Iterable, Optional, Tuple
@@ -14,7 +15,7 @@ from dpu_utils.mlutils import Vocabulary
 from .encoder import Encoder, QueryType
 
 
-class SeqEncoder(Encoder):
+class SeqEncoder(Encoder, metaclass=ABCMeta):
     @classmethod
     def get_default_hyperparameters(cls) -> Dict[str, Any]:
         encoder_hypers = { 'token_vocab_size': 10000,

--- a/src/loss.py
+++ b/src/loss.py
@@ -1,0 +1,96 @@
+from abc import ABC, abstractmethod
+from typing import *
+
+import tensorflow as tf
+
+__all__ = ("Loss", "SoftMax", "Cosine", "MaxMargin", "Triplet")
+
+
+def get_logits(query_encoded, code_encoded):
+    return tf.matmul(
+        query_encoded,
+        code_encoded,
+        transpose_a=False,
+        transpose_b=True,
+        name='code_query_cooccurrence_logits',
+    )  # B x B
+
+
+class Loss(ABC):
+    @abstractmethod
+    def make_loss(self, query_encoded, code_encoded):
+        pass
+
+
+class _SoftMax(Loss):
+    def make_loss(self, query_encoded, code_encoded) -> Tuple[Any, Any]:
+        logits = get_logits(query_encoded, code_encoded)
+        per_sample_loss = tf.nn.sparse_softmax_cross_entropy_with_logits(
+            labels=tf.range(tf.shape(code_encoded)[0]),  # [0, 1, 2, 3, ..., n]
+            logits=logits,
+        )
+        return logits, per_sample_loss
+
+
+class Cosine(Loss):
+    def __init__(self, margin):
+        self.margin = margin
+
+    def make_loss(self, query_encoded, code_encoded):
+        query_norms = tf.norm(query_encoded, axis=-1, keep_dims=True) + 1e-10
+        code_norms = tf.norm(code_encoded, axis=-1, keep_dims=True) + 1e-10
+        cosine_similarities = get_logits(query_encoded / query_norms, code_encoded / code_norms)
+        # A max-margin-like loss, but do not penalize negative cosine similarities.
+        neg_matrix = tf.diag(tf.fill(dims=[tf.shape(cosine_similarities)[0]], value=float('-inf')))
+        per_sample_loss = tf.maximum(
+            0.,
+            self.margin - tf.diag_part(cosine_similarities)
+            + tf.reduce_max(tf.nn.relu(cosine_similarities + neg_matrix), axis=-1),
+        )
+        return cosine_similarities, per_sample_loss
+
+
+class MaxMargin(Loss):
+    def __init__(self, margin):
+        self.margin = margin
+
+    def make_loss(self, query_encoded, code_encoded):
+        logits = get_logits(query_encoded, code_encoded)
+        logprobs = tf.nn.log_softmax(logits)
+        min_inf_matrix = tf.diag(tf.fill(dims=[tf.shape(logprobs)[0]], value=float('-inf')))
+        per_sample_loss = tf.maximum(
+            0.,
+            self.margin - tf.diag_part(logprobs) + tf.reduce_max(logprobs + min_inf_matrix, axis=-1),
+        )
+        return logits, per_sample_loss
+
+
+class Triplet(Loss):
+    def __init__(self, margin):
+        self.margin = margin
+
+    def make_loss(self, query_encoded, code_encoded):
+        query_reps = tf.broadcast_to(
+            query_encoded,
+            shape=[tf.shape(query_encoded)[0], tf.shape(query_encoded)[0], tf.shape(query_encoded)[1]],
+        )  # B*xBxD
+        code_reps = tf.broadcast_to(
+            code_encoded,
+            shape=[tf.shape(code_encoded)[0], tf.shape(code_encoded)[0], tf.shape(code_encoded)[1]],
+        )  # B*xBxD
+        code_reps = tf.transpose(code_reps, perm=(1, 0, 2))  # BxB*xD
+
+        all_pair_distances = tf.norm(query_reps - code_reps, axis=-1)  # BxB
+        correct_distances = tf.expand_dims(tf.diag_part(all_pair_distances), axis=-1)  # Bx1
+
+        pointwise_loss = tf.nn.relu(correct_distances - all_pair_distances + self.margin)  # BxB
+        pointwise_loss *= (1 - tf.eye(tf.shape(pointwise_loss)[0]))
+
+        per_sample_loss = tf.reduce_sum(pointwise_loss, axis=-1) / (
+                    tf.reduce_sum(tf.cast(tf.greater(pointwise_loss, 0), dtype=tf.float32), axis=-1) + 1e-10)  # B
+
+        return -all_pair_distances, per_sample_loss
+
+
+# singleton for the unparametrized softmax loss
+SoftMax = _SoftMax()

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -1,0 +1,79 @@
+from collections import defaultdict
+from typing import *
+
+from dpu_utils.utils import RichPath
+
+from encoders import Encoder
+from utils.general_utils import get_data_files_from_directory
+from utils.py_utils import run_jobs_in_parallel
+
+__all__ = ("Metadata", "MetadataLoader")
+
+Metadata = Dict[str, Any]
+
+
+class MetadataLoader:
+    def __init__(
+            self,
+            query_encoder_type: Type[Encoder],
+            code_encoder_types: Callable[[str], Type[Encoder]],
+            hyperparameters: Dict[str, Any],
+    ):
+        self.query_encoder_type = query_encoder_type
+        self.code_encoder_types = code_encoder_types
+        self.raw_query_metadata_list = []
+        self.raw_code_language_metadata_lists: DefaultDict[str, list] = defaultdict(list)
+        self.hyperparameters = hyperparameters
+
+    def init_code_metadata(self, language: str):
+        return self.code_encoder_types(language).init_metadata()
+
+    def metadata_parser_fn(self, _, file_path: RichPath) -> Iterable[Tuple[Metadata, Dict[str, Metadata]]]:
+        raw_query_metadata: Metadata = self.query_encoder_type.init_metadata()
+        per_code_language_metadata: Dict[str, Metadata] = {}
+
+        for raw_sample in file_path.read_by_file_suffix():
+            sample_language = raw_sample['language']
+            self.code_encoder_types(sample_language).load_metadata_from_sample(
+                raw_sample['code_tokens'],
+                per_code_language_metadata.setdefault(sample_language, self.init_code_metadata(sample_language)),
+                self.hyperparameters['code_use_subtokens'],
+                self.hyperparameters['code_mark_subtoken_end'],
+            )
+            self.query_encoder_type.load_metadata_from_sample(
+                [d.lower() for d in raw_sample['docstring_tokens']],
+                raw_query_metadata,
+            )
+        yield (raw_query_metadata, per_code_language_metadata)
+
+    def received_result_callback(self, metadata_parser_result: Tuple[Metadata, Dict[str, Metadata]]):
+        (raw_query_metadata, per_code_language_metadata) = metadata_parser_result
+        self.raw_query_metadata_list.append(raw_query_metadata)
+        for metadata_language, raw_code_language_metadata in per_code_language_metadata.items():
+            self.raw_code_language_metadata_lists[metadata_language].append(raw_code_language_metadata)
+
+    def load_parallel(self, data_dirs: List[RichPath], max_files_per_dir: Optional[int] = None):
+        run_jobs_in_parallel(
+            get_data_files_from_directory(data_dirs, max_files_per_dir),
+            self.metadata_parser_fn,
+            self.received_result_callback,
+            noop,
+        )
+
+    def load_sequential(self, data_dirs: List[RichPath], max_files_per_dir: Optional[int] = None):
+        for (idx, file) in enumerate(get_data_files_from_directory(data_dirs, max_files_per_dir)):
+            for res in self.metadata_parser_fn(idx, file):
+                self.received_result_callback(res)
+
+    def finalize_metadata(self) -> Tuple[Metadata, Dict[str, Metadata]]:
+        query_metadata = self.query_encoder_type.finalise_metadata("query", self.hyperparameters, self.raw_query_metadata_list)
+        code_metadata = {}
+        for language, raw_per_language_metadata in self.raw_code_language_metadata_lists.items():
+            code_metadata[language] = self.code_encoder_types(language).finalise_metadata(
+                "code", self.hyperparameters, raw_per_language_metadata
+            )
+        return query_metadata, code_metadata
+
+
+def noop():
+    pass

--- a/src/model_test.py
+++ b/src/model_test.py
@@ -1,21 +1,18 @@
-from collections import defaultdict
+import logging
 from itertools import chain
 from typing import Optional, List, Dict, Any, NamedTuple, Iterable, Tuple
-import logging
-import random
 
+import numpy as np
+import wandb
+from dpu_utils.codeutils import split_identifier_into_parts
 from dpu_utils.mlutils import Vocabulary
 from dpu_utils.utils import RichPath
-import numpy as np
-from more_itertools import chunked, flatten
+from more_itertools import chunked
 from scipy.spatial.distance import cdist
-import wandb
 
 import model_restore_helper
-from models.model import get_data_files_from_directory, Model
-from dataextraction.python.parse_python_data import tokenize_python_from_string
-from dataextraction.utils import tokenize_docstring_from_string
-from dpu_utils.codeutils import split_identifier_into_parts
+from models.model import Model
+from utils.general_utils import get_data_files_from_directory
 
 
 def compute_ranks(src_representations: np.ndarray,

--- a/src/models/conv_model.py
+++ b/src/models/conv_model.py
@@ -1,10 +1,16 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Type
 
-from encoders import ConvolutionSeqEncoder
+from encoders import ConvolutionSeqEncoder, Encoder
 from .model import Model
 
 
 class ConvolutionalModel(Model):
+    query_encoder_type = ConvolutionSeqEncoder
+
+    @classmethod
+    def code_encoder_type(cls, language: str) -> Type[Encoder]:
+        return ConvolutionSeqEncoder
+
     @classmethod
     def get_default_hyperparameters(cls) -> Dict[str, Any]:
         hypers = {}
@@ -28,8 +34,6 @@ class ConvolutionalModel(Model):
                  log_save_dir: Optional[str] = None):
         super().__init__(
             hyperparameters,
-            code_encoder_type=ConvolutionSeqEncoder,
-            query_encoder_type=ConvolutionSeqEncoder,
             run_name=run_name,
             model_save_dir=model_save_dir,
             log_save_dir=log_save_dir)

--- a/src/models/conv_self_att_model.py
+++ b/src/models/conv_self_att_model.py
@@ -1,10 +1,16 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Type
 
-from encoders import ConvSelfAttentionEncoder
+from encoders import ConvSelfAttentionEncoder, Encoder
 from .model import Model
 
 
 class ConvSelfAttentionModel(Model):
+    query_encoder_type = ConvSelfAttentionEncoder
+
+    @classmethod
+    def code_encoder_type(cls, language: str) -> Type[Encoder]:
+        return ConvSelfAttentionEncoder
+
     @classmethod
     def get_default_hyperparameters(cls) -> Dict[str, Any]:
         hypers = {}
@@ -28,8 +34,6 @@ class ConvSelfAttentionModel(Model):
                  log_save_dir: Optional[str] = None):
         super().__init__(
             hyperparameters,
-            code_encoder_type=ConvSelfAttentionEncoder,
-            query_encoder_type=ConvSelfAttentionEncoder,
             run_name=run_name,
             model_save_dir=model_save_dir,
             log_save_dir=log_save_dir)

--- a/src/models/model.py
+++ b/src/models/model.py
@@ -295,10 +295,12 @@ class Model(ABC):
 
         if parallelize:
             loader.load_parallel(data_dirs, max_files_per_dir)
+            finalized = loader.finalize_parallel()
         else:
             loader.load_sequential(data_dirs, max_files_per_dir)
+            finalized = loader.finalize_metadata()
 
-        self.__query_metadata, self.__per_code_language_metadata = loader.finalize_metadata()
+        self.__query_metadata, self.__per_code_language_metadata = finalized
 
     def load_existing_metadata(self, metadata_path: RichPath):
         saved_data = metadata_path.read_by_file_suffix()

--- a/src/models/nbow_model.py
+++ b/src/models/nbow_model.py
@@ -1,10 +1,16 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Type
 
-from encoders import NBoWEncoder
+from encoders import NBoWEncoder, Encoder
 from .model import Model
 
 
 class NeuralBoWModel(Model):
+    query_encoder_type = NBoWEncoder
+
+    @classmethod
+    def code_encoder_type(cls, language: str) -> Type[Encoder]:
+        return NBoWEncoder
+
     @classmethod
     def get_default_hyperparameters(cls) -> Dict[str, Any]:
         hypers = {}
@@ -28,8 +34,6 @@ class NeuralBoWModel(Model):
                  log_save_dir: Optional[str] = None):
         super().__init__(
             hyperparameters,
-            code_encoder_type=NBoWEncoder,
-            query_encoder_type=NBoWEncoder,
             run_name=run_name,
             model_save_dir=model_save_dir,
             log_save_dir=log_save_dir)

--- a/src/models/rnn_model.py
+++ b/src/models/rnn_model.py
@@ -1,10 +1,16 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Type
 
-from encoders import RNNEncoder
+from encoders import RNNEncoder, Encoder
 from models import Model
 
 
 class RNNModel(Model):
+    query_encoder_type = RNNEncoder
+
+    @classmethod
+    def code_encoder_type(cls, language: str) -> Type[Encoder]:
+        return RNNEncoder
+
     @classmethod
     def get_default_hyperparameters(cls) -> Dict[str, Any]:
         hypers = {}
@@ -27,8 +33,6 @@ class RNNModel(Model):
                  log_save_dir: Optional[str] = None):
         super().__init__(
             hyperparameters,
-            code_encoder_type=RNNEncoder,
-            query_encoder_type=RNNEncoder,
             run_name=run_name,
             model_save_dir=model_save_dir,
             log_save_dir=log_save_dir)

--- a/src/models/self_att_model.py
+++ b/src/models/self_att_model.py
@@ -1,10 +1,16 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Type
 
-from encoders import SelfAttentionEncoder
+from encoders import SelfAttentionEncoder, Encoder
 from models import Model
 
 
 class SelfAttentionModel(Model):
+    query_encoder_type = SelfAttentionEncoder
+
+    @classmethod
+    def code_encoder_type(cls, language: str) -> Type[Encoder]:
+        return SelfAttentionEncoder
+
     @classmethod
     def get_default_hyperparameters(cls) -> Dict[str, Any]:
         hypers = {}
@@ -28,8 +34,6 @@ class SelfAttentionModel(Model):
                  log_save_dir: Optional[str] = None):
         super().__init__(
             hyperparameters,
-            code_encoder_type=SelfAttentionEncoder,
-            query_encoder_type=SelfAttentionEncoder,
             run_name=run_name,
             model_save_dir=model_save_dir,
             log_save_dir=log_save_dir)

--- a/src/train.py
+++ b/src/train.py
@@ -83,8 +83,11 @@ def run_train(model_class: Type[Model],
     
     wandb.config.update(model.hyperparameters)
     model.train_log("Loading training and validation data.")
-    train_data = model.load_data_from_dirs(train_data_dirs, is_test=False, max_files_per_dir=max_files_per_dir, parallelize=parallelize)
-    valid_data = model.load_data_from_dirs(valid_data_dirs, is_test=False, max_files_per_dir=max_files_per_dir, parallelize=parallelize)
+    dataloader = model.dataloader()
+    train_data, _train_samples_cnt = dataloader.load_data_from_dirs(
+        train_data_dirs, is_test=False, max_files_per_dir=max_files_per_dir, parallelize=parallelize)
+    valid_data, _valid_samples_cnt = dataloader.load_data_from_dirs(
+        valid_data_dirs, is_test=False, max_files_per_dir=max_files_per_dir, parallelize=parallelize)
     model.train_log("Begin Training.")
     model_path = model.train(train_data, valid_data, azure_info_path, quiet=quiet, resume=resume)
     return model_path

--- a/src/utils/general_utils.py
+++ b/src/utils/general_utils.py
@@ -1,6 +1,9 @@
-from typing import List, Any
+from typing import *
 import pickle
+
+import numpy as np
 import pandas as pd
+from dpu_utils.utils import RichPath
 
 
 def save_file_pickle(fname: str, obj: Any) -> None:
@@ -17,3 +20,18 @@ def load_file_pickle(fname: str) -> None:
 def chunkify(df: pd.DataFrame, n: int) -> List[pd.DataFrame]:
     "turn pandas.dataframe into equal size n chunks."
     return [df[i::n] for i in range(n)]
+
+
+def get_data_files_from_directory(
+        data_dirs: List[RichPath],
+        max_files_per_dir: Optional[int] = None,
+) -> List[RichPath]:
+    files = []  # type: List[RichPath]
+    for data_dir in data_dirs:
+        dir_files = data_dir.get_filtered_files_in_dir('*.jsonl.gz')
+        if max_files_per_dir:
+            dir_files = sorted(dir_files)[:int(max_files_per_dir)]
+        files += dir_files
+
+    np.random.shuffle(files)  # This avoids having large_file_0, large_file_1, ... subsequences
+    return files


### PR DESCRIPTION
- encoder classes are model class fields instead of constructor arguments – the constructor arguments are now sound wrt. subtyping;
- allow different encoder types for different code languages (not tested in practice);
- data, metadata loaders and losses are defined in separate modules.