### PR TITLE
fix: adding graph context wrapper

### DIFF
--- a/src/models/model.py
+++ b/src/models/model.py
@@ -758,7 +758,7 @@ class Model(ABC):
               quiet: bool = False,
               resume: bool = False) -> RichPath:
         model_path = RichPath.create(self.model_save_path, azure_info_path)
-        with self.__sess.as_default():
+        with self.__sess.graph.as_default():
             tf.set_random_seed(self.hyperparameters['seed'])
             train_data_per_lang_nums = {language: len(samples) for language, samples in train_data.items()}
             print('Training on %s samples.' % (", ".join("%i %s" % (num, lang) for (lang, num) in train_data_per_lang_nums.items())))


### PR DESCRIPTION
- Added graph context wrapper.
- Found this while trying to migrate to TF 2.0
- Training process in TF 2.0 was broken due to `TypeError: Fetch argument None has invalid type <class 'NoneType'> sess.run(init_op)`
- Doesn't break the training process in TF 1.12

References:
- [Stackoverflow](https://stackoverflow.com/questions/45093688/how-to-understand-sess-as-default-and-sess-graph-as-default/45095286)